### PR TITLE
ignore properties if value is null

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -79,6 +79,10 @@
 	function parse(def, path, val) {
 		var method;
 
+		if (val === null || val === undefined) {
+			return;
+		}
+
 		if (bmoor.isArray(val)) {
 			method = 'array';
 		} else {

--- a/dist/bmoor-schema.js
+++ b/dist/bmoor-schema.js
@@ -78,6 +78,10 @@ var bmoorSchema =
 	function parse(def, path, val) {
 		var method;
 
+		if (val === null || val === undefined) {
+			return;
+		}
+
 		if (bmoor.isArray(val)) {
 			method = 'array';
 		} else {

--- a/src/encode.js
+++ b/src/encode.js
@@ -4,6 +4,10 @@ var bmoor = require('bmoor'),
 function parse( def, path, val ){
 	var method;
 
+	if (val === null || val === undefined) {
+		return;
+	}
+	
 	if ( bmoor.isArray(val) ){
 		method = 'array';
 	}else{

--- a/src/encode.spec.js
+++ b/src/encode.spec.js
@@ -18,4 +18,15 @@ describe('bmoor-schema.encode', function(){
 
 		expect( encoding.length ).toBe( 4 );
 	});
+
+	it('should ignore null and undefined values', function() {
+		var encoding = encode({
+			foo: 'bar',
+			nullObj: null,
+			undefinedObj: undefined
+		});
+
+		expect(encoding.length).toBe(1);
+		expect(encoding).toEqual([{path: 'foo', type: 'string', sample: 'bar'}]);
+	});
 });


### PR DESCRIPTION
An exception is thrown when the json property value is null or undefined. I added a check to just return (and thus ignore) if the value is null or undefined.